### PR TITLE
Refactor locations and racks grouping to fix YANG grouping config false for RFC 9907 compliance

### DIFF
--- a/ietf-ni-location.yang
+++ b/ietf-ni-location.yang
@@ -153,213 +153,172 @@ module ietf-ni-location {
   grouping locations {
     description
       "Grouping for locations.";
-    container locations {
-      config false;
+    list location {
+      key "id";
       description
-        "Container for the location information.";
-      list location {
-        key "id";
+        "List of locations within the network.";
+      leaf id {
+        type string;
         description
-          "List of locations within the network.";
-        leaf id {
-          type string;
-          description
-            "An identifier of the location.";
-        }
-        uses nwi:basic-common-entity-attributes;
-        leaf type {
-          type string;
-          description
-            "The type of network inventory location, e.g.
-             equipment room, building, or site.
-             This allows operators to flexibly define custom location
-             types (e.g., 'pole', 'roof', 'floor') based on their
-             specific network scenarios without requiring model
-             extensions. String-based types enable dynamic adaptation
-             to heterogeneous organizational naming conventions.";
-        }
-        leaf parent {
-          type leafref {
-            path "../../location/id";
-          }
-          description
-            "The identifier of the location that physically contains
-             this location.";
-        }
-        leaf timestamp {
-          type yang:date-and-time;
-          description
-            "Timestamp when the location was recorded.";
-        }
-        leaf valid-until {
-          type yang:date-and-time;
-          description
-            "The timestamp for which this location is valid until.
-             If unspecified, the location has no specific
-             expiration time.";
-        }
-        uses physical-address;
-        uses geo:geo-location;
-        list contained-chassis {
-          key "chassis-id";
-          description
-            "Chassis directly deployed in this location without rack.
-             Also used for distributed chassis components that are
-             logically part of a network element but physically
-             located.";
-          leaf chassis-id {
-            type uint32;
-            description
-              "Unique identifier for this chassis instance in the
-               location.";
-          }
-          leaf ne-ref {
-            type leafref {
-              path "/nwi:network-inventory/nwi:network-elements"
-                 + "/nwi:network-element/nwi:ne-id";
-            }
-            description
-              "Reference to the network element this chassis
-               belongs to. Multiple chassis entries may reference
-               the same ne-ref for distributed systems.";
-          }
-          leaf component-ref {
-            type leafref {
-              path
-                "/nwi:network-inventory/nwi:network-elements"
-              + "/nwi:network-element[nwi:ne-id=current()/../ne-ref]"
-              + "/nwi:components/nwi:component/nwi:component-id";
-            }
-            description
-              "Reference to the specific chassis within the
-               network element.";
-          }
-        }
+          "An identifier of the location.";
       }
-      uses racks;
+      uses nwi:basic-common-entity-attributes;
+      leaf type {
+        type string;
+        description
+          "The type of network inventory location, e.g.
+           equipment room, building, or site.
+           This allows operators to flexibly define custom location
+           types (e.g., 'pole', 'roof', 'floor') based on their
+           specific network scenarios without requiring model
+           extensions. String-based types enable dynamic adaptation
+           to heterogeneous organizational naming conventions.";
+      }
+      leaf parent {
+        type leafref {
+          path "../../location/id";
+        }
+        description
+          "The identifier of the location that physically contains
+           this location.";
+      }
+      leaf timestamp {
+        type yang:date-and-time;
+        description
+          "Timestamp when the location was recorded.";
+      }
+      leaf valid-until {
+        type yang:date-and-time;
+        description
+          "The timestamp for which this location is valid until.
+           If unspecified, the location has no specific
+           expiration time.";
+      }
+      uses physical-address;
+      uses geo:geo-location;
+      list contained-chassis {
+        key "chassis-id";
+        description
+          "Chassis directly deployed in this location without rack.
+           Also used for distributed chassis components that are
+           logically part of a network element but physically
+           located.";
+        leaf chassis-id {
+          type uint32;
+          description
+            "Unique identifier for this chassis instance in the
+             location.";
+        }
+        uses nwi:component-ref;
+      }
     }
   }
 
   grouping racks {
     description
       "Grouping for rack attributes.";
-    container racks {
-      config false; // Enforce Read-Only     
+    list rack {
+      key "id";
       description
-        "Top-level container for the list of racks.";
-      list rack {
-        key "id";
+        "List of racks within the inventory (e.g., in an
+         equipment room).";
+      leaf id {
+        type string;
         description
-          "List of racks within the inventory (e.g., in an
-           equipment room).";
-        leaf id {
-          type string;
-          description
-            "An identifier that uniquely identifies the rack.";
+          "An identifier that uniquely identifies the rack.";
+      }
+      leaf rack-class {
+        type identityref {
+          base rack-class-type;
         }
-        leaf rack-class {
-          type identityref {
-            base rack-class-type;
-          }
+        description
+          "Classification of the rack.";
+      }
+      uses nwi:basic-common-entity-attributes;
+      container rack-location {
+        description
+          "The location information of the rack, which comprises
+           the location reference, row number, and column number.";
+        leaf location-ref {
+          type ni-location-ref;
           description
-            "Classification of the rack.";
+            "Reference to the location where this rack is placed.";
         }
-        uses nwi:basic-common-entity-attributes;
-        container rack-location {
+        leaf row-number {
+          type uint32;
           description
-            "The location information of the rack, which comprises
-             the location reference, row number, and column number.";
-          leaf location-ref {
-            type ni-location-ref;
-            description
-              "Reference to the location where this rack is placed.";
-          }
-          leaf row-number {
-            type uint32;
-            description
-              "Identifies the row within the location where
-               the rack is located.";
-          }
-          leaf column-number {
-            type uint32;
-            description
-              "Identifies the column within the location where
-               the rack is located.";
-          }
+            "Identifies the row within the location where
+             the rack is located.";
         }
-        leaf height {
-          type uint16;
-          units "millimeter";
+        leaf column-number {
+          type uint32;
           description
-            "Rack height.";
+            "Identifies the column within the location where
+             the rack is located.";
         }
-        leaf width {
-          type uint16;
-          units "millimeter";
+      }
+      leaf height {
+        config false;
+        type uint16;
+        units "millimeter";
+        description
+          "Physical height of the rack.
+           This is a fixed physical specification and cannot be
+           modified.";
+      }
+      leaf width {
+        config false;
+        type uint16;
+        units "millimeter";
+        description
+          "Physical width of the rack.
+           This is a fixed physical specification and cannot be
+           modified.";
+      }
+      leaf depth {
+        config false;
+        type uint16;
+        units "millimeter";
+        description
+          "Physical depth of the rack.
+           This is a fixed physical specification and cannot be
+           modified.";
+      }
+      leaf max-voltage {
+        type uint16;
+        units "volt";
+        description
+          "The maximum voltage supported by the rack.";
+      }
+      leaf max-allocated-power {
+        type uint16;
+        units "watts";
+        description
+          "The maximum allocated power for the rack.";
+      }
+      list contained-chassis {
+        key "relative-position";
+        description
+          "The list of chassis within a rack.";
+        leaf relative-position {
+          type uint8;
           description
-            "Rack width.";
+            "Relative position (e.g., U-slot) of chassis within
+             the rack.";
         }
-        leaf depth {
-          type uint16;
-          units "millimeter";
-          description
-            "Rack depth.";
-        }
-        leaf max-voltage {
-          type uint16;
-          units "volt";
-          description
-            "The maximum voltage supported by the rack.";
-        }
-        leaf max-allocated-power {
-          type uint16;
-          units "watts";
-          description
-            "The maximum allocated power for the rack.";
-        }
-        list contained-chassis {
-          key "relative-position";
-          description
-            "The list of chassis within a rack.";
-          leaf relative-position {
-            type uint8;
-            description
-              "Relative position (e.g., U-slot) of chassis within
-               the rack.";
-          }
-          leaf ne-ref {
-            type leafref {
-              path "/nwi:network-inventory/nwi:network-elements"
-                 + "/nwi:network-element/nwi:ne-id";
-            }
-            description
-              "Reference to the network element containing
-               the chassis component.";
-          }
-          leaf component-ref {
-            type leafref {
-              path "/nwi:network-inventory/nwi:network-elements"
-                 + "/nwi:network-element[nwi:ne-id=current()/.."
-                 + "/ne-ref]/nwi:components/nwi:component"
-                 + "/nwi:component-id";
-            }
-            description
-              "The reference to the chassis component within
-               the network element and contained by the rack.";
-          }
-        }
-        leaf timestamp {
-          type yang:date-and-time;
-          description
-            "Timestamp when the rack information was recorded.";
-        }
-        leaf valid-until {
-          type yang:date-and-time;
-          description
-            "The timestamp for which this rack is valid until.
-             If unspecified, the rack has no specific
-             expiration time.";
-        }
+        uses nwi:component-ref;
+      }
+      leaf timestamp {
+        type yang:date-and-time;
+        description
+          "Timestamp when the rack information was recorded.";
+      }
+      leaf valid-until {
+        type yang:date-and-time;
+        description
+          "The timestamp for which this rack is valid until.
+           If unspecified, the rack has no specific
+           expiration time.";
       }
     }
   }
@@ -367,6 +326,17 @@ module ietf-ni-location {
   augment "/nwi:network-inventory" {
     description
       "Provides location information for network inventory.";
-    uses locations;
+    container locations {
+      config false;
+      description
+        "Container for location information.";
+      uses locations;
+      container racks {
+        config false;
+        description
+          "Container for rack information.";
+        uses racks;
+      }
+    }
   }
 }


### PR DESCRIPTION
Refactor location and rack definitions to use lists instead of containers, enhancing structure and clarity.